### PR TITLE
Fix Docker Image by Updating Spring Boot Classpath

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY --from=builder application/dependencies/ ./
 COPY --from=builder application/spring-boot-loader/ ./
 COPY --from=builder application/snapshot-dependencies/ ./
 COPY --from=builder application/application/ ./
-ENTRYPOINT exec java $JAVA_OPTS org.springframework.boot.loader.JarLauncher
+ENTRYPOINT exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher


### PR DESCRIPTION
Running the docker image fails with the following error:

`Error: Could not find or load main class org.springframework.boot.loader.JarLauncher
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.loader.JarLauncher`

The entrypoint for Spring Boot was changed in version 3.2. Editing the Dockerfile is a quick and easy fix.